### PR TITLE
Added param 'config' to serve function

### DIFF
--- a/sesamutils/flask.py
+++ b/sesamutils/flask.py
@@ -1,19 +1,24 @@
 import cherrypy
 
 
-def serve(app, port=5000):
-    """Serve Flask app with production settings"""
-
+def serve(app, port=5000, config={}) -> None:
+    """
+    Serve Flask app with production settings
+    :param app: Flask application object
+    :param port: on which port to run
+    :param config: additional config dictionary
+    :return:
+    """
     cherrypy.tree.graft(app, '/')
 
     # Set the configuration of the web server to production mode
-    cherrypy.config.update({
+    cherrypy.config.update({**{
         'environment': 'production',
         'engine.autoreload_on': False,
         'log.screen': True,
         'server.socket_port': port,
         'server.socket_host': '0.0.0.0'
-    })
+    }, **config})
 
     # Start the CherryPy WSGI web server
     cherrypy.engine.start()


### PR DESCRIPTION
Added new optional param 'config', which is by default empty dictionary. It will allow us to customize Cherrypy startup options if needed